### PR TITLE
Fix parameter handling for mcp-server-filesystem

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ cd mcp-config
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -e ".[dev]"
+
+pip uninstall mcp-code-checker mcp-server-filesystem
+pip install "mcp-code-checker @ git+https://github.com/MarcusJellinghaus/mcp-code-checker.git"
+pip install "mcp-server-filesystem @ git+https://github.com/MarcusJellinghaus/mcp_server_filesystem.git"
+
 ```
 
 ## Development Tools

--- a/src/mcp_config/integration.py
+++ b/src/mcp_config/integration.py
@@ -185,8 +185,10 @@ def _build_server_config_with_cli_detection(
                 ):
                     normalized_params["python_executable"] = effective_python
             elif server_config.name == "mcp-server-filesystem":
-                # Remove python_executable for filesystem server if present
+                # Remove python_executable and venv_path for filesystem server if present
+                # The filesystem server doesn't support these parameters in CLI mode
                 normalized_params.pop("python_executable", None)
+                normalized_params.pop("venv_path", None)
 
             args = server_config.generate_args(normalized_params, use_cli_command=True)
             return {
@@ -207,8 +209,10 @@ def _build_server_config_with_cli_detection(
         ):
             normalized_params["python_executable"] = effective_python
     elif server_config.name == "mcp-server-filesystem":
-        # Remove python_executable for filesystem server
+        # Remove python_executable and venv_path for filesystem server
+        # The filesystem server doesn't support these parameters
         normalized_params.pop("python_executable", None)
+        normalized_params.pop("venv_path", None)
 
     # Generate args without the main script path (CLI mode)
     args = server_config.generate_args(normalized_params, use_cli_command=True)

--- a/src/mcp_config/servers.py
+++ b/src/mcp_config/servers.py
@@ -169,6 +169,24 @@ class ServerConfig:
             if value is None:
                 continue
 
+            # Skip venv-path for mcp-server-filesystem in CLI command mode
+            # The filesystem server doesn't support this parameter
+            if (
+                self.name == "mcp-server-filesystem"
+                and param.name == "venv-path"
+                and use_cli_command
+            ):
+                continue
+
+            # Skip python-executable for mcp-server-filesystem in CLI command mode
+            # The filesystem server doesn't support this parameter
+            if (
+                self.name == "mcp-server-filesystem"
+                and param.name == "python-executable"
+                and use_cli_command
+            ):
+                continue
+
             # Always include python-executable parameter for reliable execution
             # (Previously skipped in CLI command mode, but now we always want it)
 

--- a/tests/test_config/test_filesystem_venv_fix.py
+++ b/tests/test_config/test_filesystem_venv_fix.py
@@ -3,8 +3,13 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from mcp_config.integration import generate_client_config  # type: ignore[import-untyped]
-from mcp_config.servers import MCP_FILESYSTEM_SERVER, MCP_CODE_CHECKER  # type: ignore[import-untyped]
+from mcp_config.integration import (
+    generate_client_config,  # type: ignore[import-untyped]
+)
+from mcp_config.servers import (  # type: ignore[import-untyped]
+    MCP_CODE_CHECKER,
+    MCP_FILESYSTEM_SERVER,
+)
 
 
 def test_filesystem_server_no_venv_path() -> None:
@@ -13,15 +18,11 @@ def test_filesystem_server_no_venv_path() -> None:
         params = {
             "project_dir": "/test/project",
             "venv_path": "/test/project/.venv",
-            "log_level": "INFO"
+            "log_level": "INFO",
         }
-        
-        config = generate_client_config(
-            MCP_FILESYSTEM_SERVER,
-            "test-fs",
-            params
-        )
-        
+
+        config = generate_client_config(MCP_FILESYSTEM_SERVER, "test-fs", params)
+
         # The fix: venv-path should NOT be in arguments
         assert "--venv-path" not in config["args"]
 
@@ -33,14 +34,10 @@ def test_code_checker_keeps_venv_path() -> None:
             "project_dir": "/test/project",
             "venv_path": "/test/project/.venv",
             "python_executable": "/usr/bin/python3",
-            "log_level": "INFO"
+            "log_level": "INFO",
         }
-        
-        config = generate_client_config(
-            MCP_CODE_CHECKER,
-            "test-checker",
-            params
-        )
-        
+
+        config = generate_client_config(MCP_CODE_CHECKER, "test-checker", params)
+
         # Code-checker should still get venv-path
         assert "--venv-path" in config["args"]

--- a/tests/test_config/test_filesystem_venv_fix.py
+++ b/tests/test_config/test_filesystem_venv_fix.py
@@ -1,6 +1,5 @@
 """Test that mcp-server-filesystem doesn't include venv-path in CLI mode."""
 
-from pathlib import Path
 from unittest.mock import patch
 
 from mcp_config.integration import (

--- a/tests/test_config/test_filesystem_venv_fix.py
+++ b/tests/test_config/test_filesystem_venv_fix.py
@@ -1,0 +1,46 @@
+"""Test that mcp-server-filesystem doesn't include venv-path in CLI mode."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from mcp_config.integration import generate_client_config  # type: ignore[import-untyped]
+from mcp_config.servers import MCP_FILESYSTEM_SERVER, MCP_CODE_CHECKER  # type: ignore[import-untyped]
+
+
+def test_filesystem_server_no_venv_path() -> None:
+    """Verify filesystem server doesn't receive venv-path parameter."""
+    with patch("shutil.which", return_value="/usr/local/bin/mcp-server-filesystem"):
+        params = {
+            "project_dir": "/test/project",
+            "venv_path": "/test/project/.venv",
+            "log_level": "INFO"
+        }
+        
+        config = generate_client_config(
+            MCP_FILESYSTEM_SERVER,
+            "test-fs",
+            params
+        )
+        
+        # The fix: venv-path should NOT be in arguments
+        assert "--venv-path" not in config["args"]
+
+
+def test_code_checker_keeps_venv_path() -> None:
+    """Verify code-checker still receives venv-path (regression test)."""
+    with patch("shutil.which", return_value="/usr/local/bin/mcp-code-checker"):
+        params = {
+            "project_dir": "/test/project",
+            "venv_path": "/test/project/.venv",
+            "python_executable": "/usr/bin/python3",
+            "log_level": "INFO"
+        }
+        
+        config = generate_client_config(
+            MCP_CODE_CHECKER,
+            "test-checker",
+            params
+        )
+        
+        # Code-checker should still get venv-path
+        assert "--venv-path" in config["args"]


### PR DESCRIPTION
## 🎯 Purpose
Fix parameter handling for mcp-server-filesystem to prevent unsupported CLI arguments from being passed.

## 🔧 Changes

### Core Fix
- **Parameter Filtering**: Remove `venv_path` and `python_executable` parameters when configuring mcp-server-filesystem server in CLI mode, as these parameters are not supported by the filesystem server.

### Modified Files

1. **`src/mcp_config/integration.py`**
   - Added logic to remove `venv_path` parameter alongside `python_executable` for filesystem server
   - Ensures clean parameter passing in both CLI detection branches

2. **`src/mcp_config/servers.py`**
   - Enhanced parameter generation logic to skip `venv-path` and `python-executable` for mcp-server-filesystem in CLI command mode
   - Added conditional checks during argument generation

3. **`CONTRIBUTING.md`**
   - Updated development setup instructions
   - Added pip uninstall/reinstall commands for mcp-code-checker and mcp-server-filesystem from GitHub repositories

### Test Coverage
- **New test file**: `tests/test_config/test_filesystem_venv_fix.py`
  - Verifies filesystem server doesn't receive `venv-path` parameter
  - Includes regression test to ensure code-checker still receives `venv-path` properly

## ✅ Impact
- **Bug Fix**: Resolves issues where mcp-server-filesystem would receive unsupported parameters causing configuration failures
- **Backwards Compatible**: Code-checker and other servers continue to work as expected
- **Improved Reliability**: Ensures proper server initialization in CLI mode

## 📝 Testing
The changes include comprehensive unit tests that verify:
- Filesystem server properly excludes unsupported parameters
- Other servers (like code-checker) maintain their expected parameter handling
