### PR TITLE
feat: add PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for setuptools-scm
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for trusted publishing
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mcp-config"
+name = "mcp-config-tool"
 dynamic = ["version"]
 authors = [
     {name = "Marcus Jellinghaus", email = "Marcus@Jellinghaus.ch"},
@@ -109,6 +109,7 @@ include = ["mcp_config*"]
 package-dir = {"" = "src"}
 
 [tool.setuptools_scm]
+tag_regex = '^(?P<version>\d+\.\d+\.\d+)$'
 # Version is automatically determined from git tags
-# Tag format: v0.1.0 -> version 0.1.0
+# Tag format: 0.1.0 -> version 0.1.0
 # Between releases: 0.1.0.devN+gHASH (includes commit count and hash)

--- a/src/mcp_config/__init__.py
+++ b/src/mcp_config/__init__.py
@@ -10,7 +10,7 @@ from .servers import registry
 try:
     from importlib.metadata import version
 
-    __version__ = version("mcp-config")
+    __version__ = version("mcp-config-tool")
 except Exception:
     # Fallback for development/editable installs without proper metadata
     __version__ = "0.0.0.dev0+unknown"

--- a/tests/test_config/test_detection.py
+++ b/tests/test_config/test_detection.py
@@ -329,15 +329,13 @@ class TestProjectDependencies:
     def test_get_dependencies_from_requirements(self, tmp_path: Path) -> None:
         """Test reading dependencies from requirements.txt."""
         req_file = tmp_path / "requirements.txt"
-        req_file.write_text(
-            """# Comment
+        req_file.write_text("""# Comment
 requests>=2.28.0
 numpy==1.24.0
 
 # Another comment
 pandas
-"""
-        )
+""")
 
         deps = get_project_dependencies(tmp_path)
         assert "requests>=2.28.0" in deps
@@ -359,8 +357,7 @@ pandas
     def test_get_dependencies_from_pyproject(self, tmp_path: Path) -> None:
         """Test reading dependencies from pyproject.toml."""
         pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text(
-            """[project]
+        pyproject.write_text("""[project]
 name = "test-project"
 dependencies = [
     "requests>=2.28.0",
@@ -370,8 +367,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "black"]
 test = ["coverage"]
-"""
-        )
+""")
 
         # Mock tomllib import
         mock_toml_data = {


### PR DESCRIPTION
## Summary
- Add `publish.yml` GitHub Actions workflow using trusted publishing (no API token needed)
- Rename package to `mcp-config-tool` for PyPI availability
- Add `tag_regex` for setuptools-scm to match existing tag format (no `v` prefix)

## Setup required
1. On PyPI: add pending publisher for `mcp-config-tool` with workflow `publish.yml` and environment `pypi`
2. On GitHub: create environment named `pypi` under repo Settings > Environments
3. Create a GitHub release with a version tag (e.g. `0.2.0`) to trigger publishing

## Test plan
- [x] Verified `python -m build` succeeds locally
- [ ] Create a GitHub release and verify the workflow publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)